### PR TITLE
Fix bg and ground using wrong colors and more

### DIFF
--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -5,7 +5,7 @@ void reset_level(void) {
     famistudio_music_stop();
     coins = 0;
 
-    if (cube_data[0] & 1 || cube_data[1] & 1) {
+    if (!DEBUG_MODE && (cube_data[0] & 1 || cube_data[1] & 1)) {
         famistudio_sfx_play(sfx_death, 0);
         tmp1 = 0;
 	attempts++;
@@ -26,7 +26,7 @@ void reset_level(void) {
     set_scroll_y(scroll_y);
     init_rld(level);
     unrle_first_screen();
-
+    
     // load the starting ground and bg color
     tmp2 = (level_list[level][3] & 0x3f);
     pal_col(0, tmp2);
@@ -39,8 +39,6 @@ void reset_level(void) {
     else pal_col(5, (tmp2-0x10));
 
     speed = level_list[level][2];
-
-    init_sprites();
     player_x[0] = 0x0000;
     player_y[0] = 0xb000;
     player_x[1] = 0x0000;

--- a/SAUCE/functions/sprite_loading.h
+++ b/SAUCE/functions/sprite_loading.h
@@ -52,6 +52,7 @@ void init_sprites(void){
     while (spr_index < max_loaded_sprites){
         if (sprite_data[spr_index<<3] == TURN_OFF) break;
         load_next_sprite();
+		if (sprite_data[spr_index<<3 + 1] != 0) activesprites_active[spr_index] = 0;
     }
 }
 


### PR DESCRIPTION
The game was activating sprites loaded before a death after a level reset. Also removed an unecessary call to ``init_sprites()`` as it was already being called in ``unrle_first_screen();``. Another fix i did was that the game killed the player at the first attempt when switching levels if the player was supposed to die with noclip enabled.