### PR TITLE
Fix orbs

### DIFF
--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -58,6 +58,7 @@ void x_movement(){
 		}
 	}
 	if (pad_new[controllingplayer] & PAD_A) cube_data[currplayer] |= 0x02;
+	else if (!(pad[controllingplayer] & PAD_A)) cube_data[currplayer] &= 1;
 }
 
 #pragma code-name(pop)


### PR DESCRIPTION
Pressing A and then releasing it on the air still used orbs, now its more accurate to gd. Fixes #95 