### PR TITLE
REMOVED THE C STACK FROM PRACTICALLY EVERYTHING

### DIFF
--- a/LIB/crt0.s
+++ b/LIB/crt0.s
@@ -7,7 +7,7 @@
 .exportzp _VRAM_UPDATE := VRAM_UPDATE
 
     .export _exit,__STARTUP__:absolute=1
-	.export _PAL_BUF := PAL_BUF, _PAL_UPDATE := PAL_UPDATE
+	.export _PAL_BUF := PAL_BUF, _PAL_UPDATE := PAL_UPDATE, _xargs := xargs
 	.import push0,popa,popax,_main,zerobss,copydata
 
 ; Linker generated symbols
@@ -95,6 +95,8 @@ META_PTR:			.res 2
 META_PTR2:			.res 2
 DATA_PTR:			.res 2
 META_VAR:			.res 1
+
+xargs:				.res 4
 
 ;
 ; NES 2.0 header

--- a/LIB/mapper.h
+++ b/LIB/mapper.h
@@ -22,13 +22,17 @@ void __fastcall__ mmc3_set_1kb_chr_bank_3(unsigned char bank);
 // __asm__("LDA #%s", direction); \
 // __asm__("STA MMC3_REG_MIRRORING");
 
-void __fastcall__ mmc3_set_8kb_chr(unsigned char i) {
-	// bg
-    mmc3_set_1kb_chr_bank_0(i);
-    mmc3_set_1kb_chr_bank_1(i+1);
-    mmc3_set_1kb_chr_bank_2(i+2);
-    mmc3_set_1kb_chr_bank_3(i+3);
+extern unsigned char xargs[4];
+
+void _mmc3_set_8kb_chr() {
+    // bg
+    mmc3_set_1kb_chr_bank_0(xargs[0]);
+    mmc3_set_1kb_chr_bank_1(++xargs[0]);
+    mmc3_set_1kb_chr_bank_2(++xargs[0]);
+    mmc3_set_1kb_chr_bank_3(++xargs[0]);
 	// sprites
-	mmc3_set_2kb_chr_bank_0(i+4);
-    mmc3_set_2kb_chr_bank_1(i+6);
+	mmc3_set_2kb_chr_bank_0(xargs[0]+2);
+    mmc3_set_2kb_chr_bank_1(xargs[0]+4);
 }
+
+#define mmc3_set_8kb_chr(bank) (xargs[0] = bank, _mmc3_set_8kb_chr())

--- a/LIB/nesdash.h
+++ b/LIB/nesdash.h
@@ -41,18 +41,22 @@ void __fastcall__ music_update (void);
  * ======================================================================================================================
  */
 
-void __fastcall__ sfx_play(unsigned char sfx_index, unsigned char channel);
+void __fastcall__ _sfx_play(unsigned int args);
+#define sfx_play(sfx_index, channel) (__AX__ = (unsigned int)(byte(sfx_index))<<8|channel, _sfx_play(__AX__))
 
 /**
  * Update the PPU using the VRAM buffer with a single tile repeated LENGTH number of times.
  * Length must not be greater than 0x7f!
  */
-void __fastcall__ one_vram_buffer_horz_repeat(unsigned char data, unsigned char len, int ppu_address);
-void __fastcall__ one_vram_buffer_vert_repeat(unsigned char data, unsigned char len, int ppu_address);
+void __fastcall__ _one_vram_buffer_horz_repeat(unsigned long args);
+#define one_vram_buffer_horz_repeat(data, len, ppu_address) (loadBytesInSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_horz_repeat(__EAX__))
+
+void __fastcall__ _one_vram_buffer_vert_repeat(unsigned char data, unsigned char len, int ppu_address);
+#define one_vram_buffer_vert_repeat(data, len, ppu_address) (loadBytesInSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_vert_repeat(__EAX__))
 
 void __fastcall__ _draw_padded_text(unsigned long args);
 #define draw_padded_text(len, total_len, ppu_address) \
-(__AX__ = (len<<8)|(total_len<<0), __EAX__<<=16, __AX__ = ppu_address|(NT_UPD_HORZ<<8), _draw_padded_text(__EAX__))
+(loadBytesInSreg(total_len, len), __AX__ = ppu_address|(NT_UPD_HORZ<<8), _draw_padded_text(__EAX__))
 #define draw_padded_text_setAddr(data, len, total_len, ppu_address) (tmpptr1 = (void *)data, draw_padded_text(len, total_len, ppu_address))
 
 void __fastcall__ playPCM();

--- a/LIB/nesdash.h
+++ b/LIB/nesdash.h
@@ -5,7 +5,8 @@
 //in order x offset, y offset, tile, attribute
 //x=128 is end of a meta sprite
 // Note: sprid removed for speed
-void __fastcall__ oam_meta_spr_flipped(unsigned char flip,unsigned char x,unsigned char y,const unsigned char *data);
+void __fastcall__ _oam_meta_spr_flipped(unsigned long args);
+#define oam_meta_spr_flipped(flip, x, y, data)(xargs[0] = flip, storeBytesToSreg(x, y), __AX__ = (unsigned int)data, _oam_meta_spr_flipped(__EAX__))
 
 /**
  * ======================================================================================================================
@@ -42,21 +43,21 @@ void __fastcall__ music_update (void);
  */
 
 void __fastcall__ _sfx_play(unsigned int args);
-#define sfx_play(sfx_index, channel) (__AX__ = (unsigned int)(byte(sfx_index))<<8|channel, _sfx_play(__AX__))
+#define sfx_play(sfx_index, channel) (__AX__ = (unsigned int)(byte(channel))<<8|sfx_index, _sfx_play(__AX__))
 
 /**
  * Update the PPU using the VRAM buffer with a single tile repeated LENGTH number of times.
  * Length must not be greater than 0x7f!
  */
 void __fastcall__ _one_vram_buffer_horz_repeat(unsigned long args);
-#define one_vram_buffer_horz_repeat(data, len, ppu_address) (loadBytesInSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_horz_repeat(__EAX__))
+#define one_vram_buffer_horz_repeat(data, len, ppu_address) (storeBytesToSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_horz_repeat(__EAX__))
 
 void __fastcall__ _one_vram_buffer_vert_repeat(unsigned char data, unsigned char len, int ppu_address);
-#define one_vram_buffer_vert_repeat(data, len, ppu_address) (loadBytesInSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_vert_repeat(__EAX__))
+#define one_vram_buffer_vert_repeat(data, len, ppu_address) (storeBytesToSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_vert_repeat(__EAX__))
 
 void __fastcall__ _draw_padded_text(unsigned long args);
 #define draw_padded_text(len, total_len, ppu_address) \
-(loadBytesInSreg(total_len, len), __AX__ = ppu_address|(NT_UPD_HORZ<<8), _draw_padded_text(__EAX__))
+(storeBytesToSreg(total_len, len), __AX__ = ppu_address|(NT_UPD_HORZ<<8), _draw_padded_text(__EAX__))
 #define draw_padded_text_setAddr(data, len, total_len, ppu_address) (tmpptr1 = (void *)data, draw_padded_text(len, total_len, ppu_address))
 
 void __fastcall__ playPCM();
@@ -136,6 +137,6 @@ extern char PAL_BUF[32];
   (b) = __A__; \
 } while(0);
 
-#define loadWordInSreg(word) (__AX__ = word, __EAX__<<=16)
-#define loadBytesInSreg(a, b) (__AX__ = (byte(b)<<8)|byte(a), __EAX__<<=16)
-#define loadByteInSreg(byte) (__A__ = byte, __asm__("sta sreg+0"))
+#define storeWordToSreg(word) (__AX__ = word, __EAX__<<=16)
+#define storeBytesToSreg(a, b) (__AX__ = (byte(b)<<8)|byte(a), __EAX__<<=16)
+#define storeByteToSreg(byte) (__A__ = byte, __asm__("sta sreg+0"))

--- a/LIB/nesdash.h
+++ b/LIB/nesdash.h
@@ -129,4 +129,5 @@ extern char PAL_BUF[32];
 } while(0);
 
 #define loadWordInSreg(word) (__AX__ = word, __EAX__<<=16)
+#define loadBytesInSreg(a, b) (__AX__ = (byte(b)<<8)|byte(a), __EAX__<<=16)
 #define loadByteInSreg(byte) (__A__ = byte, __asm__("sta sreg+0"))

--- a/LIB/nesdash.h
+++ b/LIB/nesdash.h
@@ -49,15 +49,13 @@ void __fastcall__ _sfx_play(unsigned int args);
  * Update the PPU using the VRAM buffer with a single tile repeated LENGTH number of times.
  * Length must not be greater than 0x7f!
  */
-void __fastcall__ _one_vram_buffer_horz_repeat(unsigned long args);
-#define one_vram_buffer_horz_repeat(data, len, ppu_address) (storeBytesToSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_horz_repeat(__EAX__))
-
-void __fastcall__ _one_vram_buffer_vert_repeat(unsigned char data, unsigned char len, int ppu_address);
-#define one_vram_buffer_vert_repeat(data, len, ppu_address) (storeBytesToSreg(data, len), __AX__ = ppu_address, _one_vram_buffer_vert_repeat(__EAX__))
+void __fastcall__ _one_vram_buffer_repeat(unsigned long args);
+#define one_vram_buffer_horz_repeat(data, len, ppu_address) (storeBytesToSreg(data, len), __A__ = LSB(ppu_address), __AX__<<=8, __AX__ |= MSB(ppu_address)|NT_UPD_HORZ, _one_vram_buffer_repeat(__EAX__))
+#define one_vram_buffer_vert_repeat(data, len, ppu_address) (storeBytesToSreg(data, len), __A__ = LSB(ppu_address), __AX__<<=8, __AX__ |= MSB(ppu_address)|NT_UPD_VERT, _one_vram_buffer_repeat(__EAX__))
 
 void __fastcall__ _draw_padded_text(unsigned long args);
 #define draw_padded_text(len, total_len, ppu_address) \
-(storeBytesToSreg(total_len, len), __AX__ = ppu_address|(NT_UPD_HORZ<<8), _draw_padded_text(__EAX__))
+(storeBytesToSreg(total_len, len), __A__ = LSB(ppu_address), __AX__<<=8, __AX__ |= MSB(ppu_address)|NT_UPD_HORZ, _draw_padded_text(__EAX__))
 #define draw_padded_text_setAddr(data, len, total_len, ppu_address) (tmpptr1 = (void *)data, draw_padded_text(len, total_len, ppu_address))
 
 void __fastcall__ playPCM();

--- a/LIB/nesdash.h
+++ b/LIB/nesdash.h
@@ -127,3 +127,6 @@ extern char PAL_BUF[32];
   __asm__("pla"); \
   (b) = __A__; \
 } while(0);
+
+#define loadWordInSreg(word) (__AX__ = word, __EAX__<<=16)
+#define loadByteInSreg(byte) (__A__ = byte, __asm__("sta sreg+0"))

--- a/LIB/nesdash.h
+++ b/LIB/nesdash.h
@@ -64,6 +64,10 @@ void __fastcall__ playPCM();
 extern unsigned char parallax_scroll_column;
 extern unsigned char parallax_scroll_column_start;
 
+extern unsigned char xargs[4];
+#pragma zpsym("xargs")
+#define wxargs ((unsigned short * const)xargs)
+
 #define low_word(a) *((unsigned short*)&a)
 #define high_word(a) *((unsigned short*)&a+1)
 

--- a/LIB/nesdash.s
+++ b/LIB/nesdash.s
@@ -18,7 +18,7 @@
 
 .macpack longbranch
 
-.export _oam_meta_spr_flipped
+.export __oam_meta_spr_flipped
 .export _init_rld, _unrle_next_column, _draw_screen_R
 .export _movement
 .export _music_play, __sfx_play, _music_update
@@ -54,26 +54,16 @@ sprite_data = _sprite_data
 
 .segment "CODE"
 
-_oam_meta_spr_flipped:
-
-    sta <PTR
-    stx <PTR+1
-
-    .define FLIP TEMP+2
-
-    ldy #2      ;3 popa calls replacement, performed in reversed order
-    lda (sp),y
-    dey
-    sta <FLIP
-    lda (sp),y
-    dey
-    sta <SCRX
-    lda (sp),y
-    sta <SCRY
-    
-oam_meta_spr_flipped_params_set: ; Put &data into PTR, X and Y into SCRX and SCRY respectively
+__oam_meta_spr_flipped:
+	; AX = data
+	; sreg[0] = x
+	; sreg[1] = y
+    ; xargs[0] = flip
+	sta <PTR
+	stx <PTR+1
 
     ldx SPRID
+	ldy #0
 
 @1:
 
@@ -82,31 +72,31 @@ oam_meta_spr_flipped_params_set: ; Put &data into PTR, X and Y into SCRX and SCR
     beq @2
     iny
     clc
-    BIT <FLIP   ;   Check for bit 6 (HFLIP)
+    BIT xargs+0 ;   Check for bit 6 (HFLIP)
     BVC :+      ;__
     EOR #$FF    ;   If HLIPd, then two's complement
 	ADC #($100 - 8)	; Carry is clear
     SEC         ;__
     :           ;
-    adc <SCRX
+    adc sreg+0
     sta OAM_BUF+3,x
     lda (PTR),y     ;y offset
     INY
     clc
-    BIT <FLIP   ;   Check for bit 7 (VFLIP)
+    BIT xargs+0 ;   Check for bit 7 (VFLIP)
     BPL :+      ;__
     EOR #$FF    ;   If VLIPd, then two's complement
 	; ADC #($100 - 16)	; Carry is clear, Y is -16'd because of us using 8x16 mode
     SEC         ;__
     :           ;
-    adc <SCRY
+    adc sreg+1
     sta OAM_BUF+0,x
     lda (PTR),y     ;tile
     iny
     sta OAM_BUF+1,x
     lda (PTR),y     ;attribute
     iny
-    EOR <FLIP
+    EOR xargs+0
     sta OAM_BUF+2,x
     inx
     inx
@@ -115,14 +105,6 @@ oam_meta_spr_flipped_params_set: ; Put &data into PTR, X and Y into SCRX and SCR
     jmp @1
 
 @2:
-
-    lda <sp
-    adc #2          ;carry is always set here, so it adds 3
-    sta <sp
-    ; bcc @3    
-    ; inc <sp+1 ; lmao our stack is 32 bytes
-
-@3:
 
     stx SPRID
     rts
@@ -1273,11 +1255,11 @@ drawplayer_center_offsets:
     LDA _player_gravity+0
     BEQ :+
         LDA #$80
-    : STA <FLIP
+    : STA xargs+0
 
 	LDX _player_y+1		;
 	DEX					;	The Y of oam_meta_spr is high_byte(player_y[0])-1
-	STX <SCRY			;__
+	STX sreg+1			;__
 
     ; Set up base pointer for jump tables
     LDA _mini       ;
@@ -1303,7 +1285,7 @@ drawplayer_center_offsets:
 	TYA
 	SEC		; I decremented the Y, this is getting back at it
 	ADC drawplayer_center_offsets, X
-    STA <SCRX			;__ The X of oam_meta_spr is temp_x
+    STA sreg+0			;__ The X of oam_meta_spr is temp_x
 
     ; The switch 
     LDX _gamemode
@@ -1385,7 +1367,7 @@ drawplayer_center_offsets:
 		@don:
 			TAX
 			AND #$C0
-			STA <FLIP
+			STA xargs+0	; flip setting
 			TXA
 			AND #$07
 			TAY
@@ -1580,23 +1562,17 @@ drawplayer_center_offsets:
 		; and #$01
 		; beq :+
 		; 	lda #$40
-		; : eor <FLIP
-		; sta <FLIP
+		; : eor xargs+0
+		; sta xargs+0
 
-        lda     sp          ;
-        sec                 ;
-        sbc     #3          ;
-        sta     sp          ;__ sp -= 2
-        ; bcs     :+          ; lmao our stack is 32 bytes
-        ; dec     sp+1        ;__
-        ; :
+
 		LDA (ptr1), Y		;	Load low byte
-		STA <PTR			;__
+		PHA					;__
 		INY					;
 		LDA (ptr1), Y		;	Load high byte
-		STA <PTR+1			;__
-		LDY #$00			;__	THIS IS A MUST	
-		JMP oam_meta_spr_flipped_params_set ;__	oam_meta_spr(temp_x, high_byte(player_y[0])-1, [whatever the fuck we set here]);
+		TAX					;__
+		PLA
+		JMP __oam_meta_spr_flipped ;__	oam_meta_spr(temp_x, high_byte(player_y[0])-1, [whatever the fuck we set here]);
 
     sprite_table_table_lo:
         .byte <_CUBE, <_SHIP, <_BALL, <_UFO, <_ROBOT, <_SPIDER, <_WAVE
@@ -1616,11 +1592,11 @@ drawplayer_common := _drawplayerone::common
     LDA _player_gravity+1
     BEQ :+
         LDA #$80
-    : STA <FLIP
+    : STA xargs+0	; flip
 
     LDX _player_y+3		;
 	DEX					;	The Y of oam_meta_spr is high_byte(player_y[1])-1
-	STX <SCRY			;__
+	STX sreg+1			;__
 
     ; Set up base pointer for jump tables
     LDA _mini       ;
@@ -1646,7 +1622,7 @@ drawplayer_common := _drawplayerone::common
 	TYA
 	SEC		; I decremented the Y, this is getting back at it
 	ADC drawplayer_center_offsets, X
-    STA <SCRX			;__ The X of oam_meta_spr is temp_x
+    STA sreg+0			;__ The X of oam_meta_spr is temp_x
 
     ; The switch 
     LDX _gamemode
@@ -1728,7 +1704,7 @@ drawplayer_common := _drawplayerone::common
 		@don:
 			TAX
 			AND #$C0
-			STA <FLIP
+			STA xargs+0
 			TXA
 			AND #$07
 			TAY

--- a/LIB/nesdash.s
+++ b/LIB/nesdash.s
@@ -129,17 +129,15 @@ __oam_meta_spr_flipped:
 
 .segment "CODE_2"
 
-.export __one_vram_buffer_horz_repeat
-.proc __one_vram_buffer_horz_repeat
-	; ax = ppu_address
+.export __one_vram_buffer_repeat
+.proc __one_vram_buffer_repeat
+	; xa = ppu_address
 	; sreg[0] = data
 	; sreg[1] = len
 	ldy VRAM_INDEX
-	sta VRAM_BUF+1, y
-	txa
-    ora #$40
-WriteHiByte:
 	sta VRAM_BUF, y
+	txa
+	sta VRAM_BUF+1, y
     ; ptr1 lo byte is len, hi byte is character to repeat
     lda sreg+1
     ora #$80 ; set length + repeat byte
@@ -153,14 +151,6 @@ WriteHiByte:
     adc #4
     sta VRAM_INDEX
 	rts
-.endproc
-.export __one_vram_buffer_vert_repeat
-.proc __one_vram_buffer_vert_repeat
-	ldy VRAM_INDEX
-	sta VRAM_BUF+1, y
-	txa
-    ora #$80 ; vertical update
-    jmp __one_vram_buffer_horz_repeat::WriteHiByte
 .endproc
 
 _init_rld:
@@ -834,11 +824,11 @@ ParallaxBufferCol5:
 	.define totalLength sreg+0
 	.define textLength sreg+1
 
-	; AX = vramPtr
+	; XA = vramPtr
 	LDY VRAM_INDEX
-	STA VRAM_BUF+1, Y	;
+	STA VRAM_BUF, Y	;
 	TXA					;	vram pointer
-	STA VRAM_BUF, Y		;__
+	STA VRAM_BUF+1, Y	;__
 	LDA totalLength		;	total length
 	STA VRAM_BUF+2, Y	;__
 

--- a/LIB/nesdoug.h
+++ b/LIB/nesdoug.h
@@ -38,7 +38,8 @@ unsigned char __fastcall__ get_pad_new(unsigned char pad);
 unsigned char __fastcall__ get_frame_count(void);
 // use this internal value to time events, this ticks up every frame
 
-unsigned char __fastcall__ check_collision(void * object1, void * object2);
+unsigned char __fastcall__ _check_collision(unsigned long args);
+#define check_collision(object1, object2) (loadWordInSreg(object1), __AX__ = (unsigned int)object2, _check_collision(__EAX__))
 // expects an object (struct) where the first 4 bytes are X, Y, width, height
 // you will probably have to pass the address of the object like &object
 // the struct can be bigger than 4 bytes, as long as the first 4 bytes are X, Y, width, height
@@ -61,22 +62,26 @@ void __fastcall__ set_scroll_y(unsigned int y);
 // which aligns it with sprites, which are shifted down 1 pixel
 
 
-int __fastcall__ add_scroll_y(unsigned char add, unsigned int scroll);
+int __fastcall__ _add_scroll_y(unsigned long args);
+#define add_scroll_y(add, scroll) (loadByteInSreg(add), __AX__ = scroll, _add_scroll_y(__EAX__))
 // add a value to y scroll, keep the low byte in the 0-0xef range
 // returns y scroll, which will have to be passed to set_scroll_y
 
 
-int __fastcall__ sub_scroll_y(unsigned char sub, unsigned int scroll);
+int __fastcall__ _sub_scroll_y(unsigned long args);
+#define sub_scroll_y(sub, scroll) (loadByteInSreg(sub), __AX__ = scroll, _sub_scroll_y(__EAX__))
 // subtract a value from y scroll, keep the low byte in the 0-0xef range
 // returns y scroll, which will have to be passed to set_scroll_y
 
 
-int __fastcall__ get_ppu_addr(char nt, char x, char y);
+int __fastcall__ _get_ppu_addr(unsigned long args);
+#define get_ppu_addr(nt, x, y) (loadByteInSreg(nt), __AX__ = (x<<8)|y, _get_ppu_addr(__EAX__))
 // gets a ppu address from x and y coordinates (in pixels)
 // x is screen pixels 0-255, y is screen pixels 0-239, nt is nametable 0-3
 
 
-int __fastcall__ get_at_addr(char nt, char x, char y);
+int __fastcall__ _get_at_addr(unsigned long args);
+#define get_at_addr(nt, x, y) (loadByteInSreg(nt), __AX__ = (x<<8)|y, _get_at_addr(__EAX__))
 // gets a ppu address in the attribute table from x and y coordinates (in pixels)
 // x is screen pixels 0-255, y is screen pixels 0-239, nt is nametable 0-3
 
@@ -132,7 +137,8 @@ void __fastcall__ color_emphasis(char color);
 #define COL_EMP_DARK 0xe0
 
 
-void __fastcall__ xy_split(unsigned int x, unsigned int y);
+void __fastcall__ _xy_split(unsigned long args);
+#define xy_split(x, y) (loadWordInSreg(x), __AX__ = y, _xy_split(__EAX__))
 // a version of split that actually changes the y scroll midscreen
 // requires a sprite zero hit, or will crash
 

--- a/LIB/nesdoug.h
+++ b/LIB/nesdoug.h
@@ -15,15 +15,14 @@ void set_vram_buffer(void);
 
 
 void __fastcall__ _one_vram_buffer(unsigned long args);
-#define one_vram_buffer(data, ppu_address) (loadByteInSreg(data), __AX__ = ppu_address, _one_vram_buffer(__EAX__))
+#define one_vram_buffer(data, ppu_address) (storeByteToSreg(data), __AX__ = ppu_address, _one_vram_buffer(__EAX__))
 // to push a single byte write to the vram_buffer
 
+void __fastcall__ _multi_vram_buffer(unsigned long args);
 
-void __fastcall__ multi_vram_buffer_horz(const char * data, unsigned char len, int ppu_address);
+#define multi_vram_buffer_horz(data, len, ppu_address) (xargs[0] = len, storeWordToSreg((unsigned int)data), __A__ = LSB(ppu_address), __AX__<<=8, __AX__ |= MSB(ppu_address)|NT_UPD_HORZ, _multi_vram_buffer(__EAX__))
 // to push multiple writes as one sequential horizontal write to the vram_buffer
-
-
-void __fastcall__ multi_vram_buffer_vert(const char * data, unsigned char len, int ppu_address);
+#define multi_vram_buffer_vert(data, len, ppu_address) (xargs[0] = len, storeWordToSreg((unsigned int)data), __A__ = LSB(ppu_address), __AX__<<=8, __AX__ |= MSB(ppu_address)|NT_UPD_VERT, _multi_vram_buffer(__EAX__))
 // to push multiple writes as one sequential vertical write to the vram_buffer
 
 
@@ -40,7 +39,7 @@ unsigned char __fastcall__ get_frame_count(void);
 // use this internal value to time events, this ticks up every frame
 
 unsigned char __fastcall__ _check_collision(unsigned long args);
-#define check_collision(object1, object2) (loadWordInSreg((unsigned int)object1), __AX__ = (unsigned int)object2, _check_collision(__EAX__))
+#define check_collision(object1, object2) (storeWordToSreg((unsigned int)object1), __AX__ = (unsigned int)object2, _check_collision(__EAX__))
 // expects an object (struct) where the first 4 bytes are X, Y, width, height
 // you will probably have to pass the address of the object like &object
 // the struct can be bigger than 4 bytes, as long as the first 4 bytes are X, Y, width, height
@@ -64,25 +63,25 @@ void __fastcall__ set_scroll_y(unsigned int y);
 
 
 int __fastcall__ _add_scroll_y(unsigned long args);
-#define add_scroll_y(add, scroll) (loadByteInSreg(add), __AX__ = scroll, _add_scroll_y(__EAX__))
+#define add_scroll_y(add, scroll) (storeByteToSreg(add), __AX__ = scroll, _add_scroll_y(__EAX__))
 // add a value to y scroll, keep the low byte in the 0-0xef range
 // returns y scroll, which will have to be passed to set_scroll_y
 
 
 int __fastcall__ _sub_scroll_y(unsigned long args);
-#define sub_scroll_y(sub, scroll) (loadByteInSreg(sub), __AX__ = scroll, _sub_scroll_y(__EAX__))
+#define sub_scroll_y(sub, scroll) (storeByteToSreg(sub), __AX__ = scroll, _sub_scroll_y(__EAX__))
 // subtract a value from y scroll, keep the low byte in the 0-0xef range
 // returns y scroll, which will have to be passed to set_scroll_y
 
 
 int __fastcall__ _get_ppu_addr(unsigned long args);
-#define get_ppu_addr(nt, x, y) (loadByteInSreg(nt), __AX__ = (x<<8)|y, _get_ppu_addr(__EAX__))
+#define get_ppu_addr(nt, x, y) (storeByteToSreg(nt), __AX__ = (x<<8)|y, _get_ppu_addr(__EAX__))
 // gets a ppu address from x and y coordinates (in pixels)
 // x is screen pixels 0-255, y is screen pixels 0-239, nt is nametable 0-3
 
 
 int __fastcall__ _get_at_addr(unsigned long args);
-#define get_at_addr(nt, x, y) (loadByteInSreg(nt), __AX__ = (x<<8)|y, _get_at_addr(__EAX__))
+#define get_at_addr(nt, x, y) (storeByteToSreg(nt), __AX__ = (x<<8)|y, _get_at_addr(__EAX__))
 // gets a ppu address in the attribute table from x and y coordinates (in pixels)
 // x is screen pixels 0-255, y is screen pixels 0-239, nt is nametable 0-3
 
@@ -106,7 +105,7 @@ void __fastcall__ set_mt_pointer(const char * metatiles);
 
 
 void __fastcall__ _buffer_1_mt(unsigned long args);
-#define buffer_1_mt(ppu_address, index) (loadByteInSreg(index), __AX__ = ppu_address, _buffer_1_mt(__EAX__))
+#define buffer_1_mt(ppu_address, index) (storeByteToSreg(index), __AX__ = ppu_address, _buffer_1_mt(__EAX__))
 // will push 1 metatile and 0 attribute bytes to the vram_buffer
 // make sure to set_vram_buffer(), and clear_vram_buffer(), 
 // and set_mt_pointer() 
@@ -140,7 +139,7 @@ void __fastcall__ color_emphasis(char color);
 
 
 void __fastcall__ _xy_split(unsigned long args);
-#define xy_split(x, y) (loadWordInSreg(x), __AX__ = y, _xy_split(__EAX__))
+#define xy_split(x, y) (storeWordToSreg(x), __AX__ = y, _xy_split(__EAX__))
 // a version of split that actually changes the y scroll midscreen
 // requires a sprite zero hit, or will crash
 

--- a/LIB/nesdoug.h
+++ b/LIB/nesdoug.h
@@ -40,7 +40,7 @@ unsigned char __fastcall__ get_frame_count(void);
 // use this internal value to time events, this ticks up every frame
 
 unsigned char __fastcall__ _check_collision(unsigned long args);
-#define check_collision(object1, object2) (loadWordInSreg(object1), __AX__ = (unsigned int)object2, _check_collision(__EAX__))
+#define check_collision(object1, object2) (loadWordInSreg((unsigned int)object1), __AX__ = (unsigned int)object2, _check_collision(__EAX__))
 // expects an object (struct) where the first 4 bytes are X, Y, width, height
 // you will probably have to pass the address of the object like &object
 // the struct can be bigger than 4 bytes, as long as the first 4 bytes are X, Y, width, height
@@ -105,7 +105,8 @@ void __fastcall__ set_mt_pointer(const char * metatiles);
 // max metatiles = 51 (because 51 x 5 = 255)
 
 
-void __fastcall__ buffer_1_mt(short ppu_address, char metatile);
+void __fastcall__ _buffer_1_mt(unsigned long args);
+#define buffer_1_mt(ppu_address, index) (loadByteInSreg(index), __AX__ = ppu_address, _buffer_1_mt(__EAX__))
 // will push 1 metatile and 0 attribute bytes to the vram_buffer
 // make sure to set_vram_buffer(), and clear_vram_buffer(), 
 // and set_mt_pointer() 

--- a/LIB/nesdoug.h
+++ b/LIB/nesdoug.h
@@ -14,7 +14,8 @@ void set_vram_buffer(void);
 // this can be undone by set_vram_update(NULL)
 
 
-void __fastcall__ one_vram_buffer(unsigned char data, int ppu_address);
+void __fastcall__ _one_vram_buffer(unsigned long args);
+#define one_vram_buffer(data, ppu_address) (loadByteInSreg(data), __AX__ = ppu_address, _one_vram_buffer(__EAX__))
 // to push a single byte write to the vram_buffer
 
 

--- a/LIB/nesdoug.s
+++ b/LIB/nesdoug.s
@@ -1,7 +1,7 @@
 ;written by Doug Fraker
 ;version 1.3, 10/31/2022
 
-.export _set_vram_buffer, _multi_vram_buffer_horz, _multi_vram_buffer_vert, _one_vram_buffer
+.export _set_vram_buffer, _multi_vram_buffer_horz, _multi_vram_buffer_vert, __one_vram_buffer
 .export _get_pad_new, _get_frame_count
 .export __check_collision, __pal_fade_to, _set_scroll_x, _set_scroll_y, __add_scroll_y, __sub_scroll_y
 .export  __get_ppu_addr, _get_at_addr, _set_data_pointer, _set_mt_pointer, _buffer_4_mt, _buffer_1_mt
@@ -81,16 +81,16 @@ _multi_vram_buffer_vert:
 	
 
 ;void one_vram_buffer(unsigned char data, int ppu_address);
-_one_vram_buffer:
+__one_vram_buffer:
+	; ax = ppu_address
+	; sreg[0] = data
 	ldy VRAM_INDEX
 	sta VRAM_BUF+1, y
 	txa
 	sta VRAM_BUF, y
 	iny
 	iny
-		sty <TEMP ;popa uses y
-	jsr popa
-		ldy <TEMP
+	lda sreg
 	sta VRAM_BUF, y
 	iny
 	lda #$ff ;=NT_UPD_EOF

--- a/LIB/nesdoug.s
+++ b/LIB/nesdoug.s
@@ -296,9 +296,6 @@ _set_scroll_y:
 ;int __fastcall__ add_scroll_y(unsigned char add, unsigned int scroll);
 __add_scroll_y:
 	; sreg[0] = add, AX = scroll
-	; sta TEMP
-	; stx TEMP+1 ;x = high
-	; jsr popa
 	clc
 	adc sreg+0
 	bcs @adjust

--- a/LIB/nesdoug.s
+++ b/LIB/nesdoug.s
@@ -4,7 +4,7 @@
 .export _set_vram_buffer, _multi_vram_buffer_horz, _multi_vram_buffer_vert, __one_vram_buffer
 .export _get_pad_new, _get_frame_count
 .export __check_collision, __pal_fade_to, _set_scroll_x, _set_scroll_y, __add_scroll_y, __sub_scroll_y
-.export  __get_ppu_addr, _get_at_addr, _set_data_pointer, _set_mt_pointer, _buffer_4_mt, _buffer_1_mt
+.export  __get_ppu_addr, _get_at_addr, _set_data_pointer, _set_mt_pointer, _buffer_4_mt, __buffer_1_mt
 .export _color_emphasis, __xy_split, _gray_line, _seed_rng
 .export _clear_vram_buffer
 
@@ -614,8 +614,8 @@ _buffer_4_mt:
 	
 	
 ;void __fastcall__ buffer_1_mt(int ppu_address, char metatile);
-_buffer_1_mt:
-	;which metatile, in sreg[0]
+__buffer_1_mt:
+	; which metatile, in sreg[0]
 	; AX = ppu_address
 
 	ldy sreg+0

--- a/LIB/neslib.h
+++ b/LIB/neslib.h
@@ -228,7 +228,7 @@ void __fastcall__ _vram_read(unsigned long args);
 
 //write a block to current address of vram, works only when rendering is turned off
 
-void __fastcall__ _vram_write(const void *src,unsigned int size);
+void __fastcall__ _vram_write(unsigned long args);
 #define vram_write(src, size)(loadWordInSreg(src), __AX__ = size, _vram_write(__EAX__))
 
 //unpack RLE data to current address of vram, mostly used for nametables
@@ -239,11 +239,13 @@ void __fastcall__ vram_unrle(const void *data);
 
 //like a normal memcpy, but does not return anything
 
-void __fastcall__ memcpy(void *dst,const void *src,unsigned int len);
+void __fastcall__ _memcpy(unsigned long args);
+#define memcpy(dst, src, len) (wxargs[0] = (unsigned int)dst, loadWordInSreg((unsigned int)src), __AX__ = len, _memcpy(__EAX__))
 
 //like memset, but does not return anything
 
-void __fastcall__ memfill(void *dst,unsigned char value,unsigned int len);
+void __fastcall__ _memfill(unsigned long args);
+#define memfill(dst, val, len) (wxargs[0] = (unsigned int)dst, loadWordInSreg((unsigned int)len), __A__ = val, _memfill(__EAX__))
 
 //delay for N frames
 

--- a/LIB/neslib.h
+++ b/LIB/neslib.h
@@ -100,7 +100,7 @@ void __fastcall__ oam_size(unsigned char size);
 // Note: sprid removed for speed
 
 void __fastcall__ _oam_spr(unsigned long args);
-#define oam_spr(x, y, chrnum, attr)(loadBytesInSreg(x, y), __AX__ = (chrnum<<8)|attr, _oam_spr(__EAX__))
+#define oam_spr(x, y, chrnum, attr)(storeBytesToSreg(x, y), __AX__ = (chrnum<<8)|attr, _oam_spr(__EAX__))
 
 
 //set metasprite in OAM buffer (normal)
@@ -110,7 +110,7 @@ void __fastcall__ _oam_spr(unsigned long args);
 // Note: sprid removed for speed
 
 void __fastcall__ _oam_meta_spr(unsigned long args);
-#define oam_meta_spr(x, y, data)(loadBytesInSreg(x, y), __AX__ = (unsigned int)data, _oam_meta_spr(__EAX__))
+#define oam_meta_spr(x, y, data)(storeBytesToSreg(x, y), __AX__ = (unsigned int)data, _oam_meta_spr(__EAX__))
 
 //hide all remaining sprites from given offset
 // Note: sprid removed for speed
@@ -148,7 +148,7 @@ unsigned char __fastcall__ pad_state(unsigned char pad);
 //it is always applied at beginning of a TV frame, not at the function call
 
 void __fastcall__ _scroll(unsigned long args);
-#define scroll(x, y) (loadWordInSreg(x), __AX__ = y, _scroll(__EAX__))
+#define scroll(x, y) (storeWordToSreg(x), __AX__ = y, _scroll(__EAX__))
 
 //set scroll after screen split invoked by the sprite 0 hit
 //warning: all CPU time between the function call and the actual split point will be wasted!
@@ -215,7 +215,7 @@ void __fastcall__ flush_vram_update(const unsigned char *buf);
 //fill a block with a byte at current vram address, works only when rendering is turned off
 
 void __fastcall__ _vram_fill(unsigned long args);
-#define vram_fill(n, len) (loadByteInSreg(byte(LSB(len))), __AX__ = (byte(MSB(len)) << 8) | byte(n), _vram_fill(__EAX__))
+#define vram_fill(n, len) (storeByteToSreg(byte(LSB(len))), __AX__ = (byte(MSB(len)) << 8) | byte(n), _vram_fill(__EAX__))
 
 //set vram autoincrement, 0 for +1 and not 0 for +32
 
@@ -224,12 +224,12 @@ void __fastcall__ vram_inc(unsigned char n);
 //read a block from current address of vram, works only when rendering is turned off
 
 void __fastcall__ _vram_read(unsigned long args);
-#define vram_read(dst, size)(loadWordInSreg(dst), __AX__ = size, _vram_read(__EAX__))
+#define vram_read(dst, size)(storeWordToSreg(dst), __AX__ = size, _vram_read(__EAX__))
 
 //write a block to current address of vram, works only when rendering is turned off
 
 void __fastcall__ _vram_write(unsigned long args);
-#define vram_write(src, size)(loadWordInSreg(src), __AX__ = size, _vram_write(__EAX__))
+#define vram_write(src, size)(storeWordToSreg(src), __AX__ = size, _vram_write(__EAX__))
 
 //unpack RLE data to current address of vram, mostly used for nametables
 
@@ -240,12 +240,12 @@ void __fastcall__ vram_unrle(const void *data);
 //like a normal memcpy, but does not return anything
 
 void __fastcall__ _memcpy(unsigned long args);
-#define memcpy(dst, src, len) (wxargs[0] = (unsigned int)dst, loadWordInSreg((unsigned int)src), __AX__ = len, _memcpy(__EAX__))
+#define memcpy(dst, src, len) (wxargs[0] = (unsigned int)dst, storeWordToSreg((unsigned int)src), __AX__ = len, _memcpy(__EAX__))
 
 //like memset, but does not return anything
 
 void __fastcall__ _memfill(unsigned long args);
-#define memfill(dst, val, len) (wxargs[0] = (unsigned int)dst, loadWordInSreg((unsigned int)len), __A__ = val, _memfill(__EAX__))
+#define memfill(dst, val, len) (wxargs[0] = (unsigned int)dst, storeWordToSreg((unsigned int)len), __A__ = val, _memfill(__EAX__))
 
 //delay for N frames
 

--- a/LIB/neslib.h
+++ b/LIB/neslib.h
@@ -99,8 +99,8 @@ void __fastcall__ oam_size(unsigned char size);
 //set sprite in OAM buffer, chrnum is tile, attr is attribute
 // Note: sprid removed for speed
 
-void __fastcall__ oam_spr(unsigned char x,unsigned char y,unsigned char chrnum,unsigned char attr);
-
+void __fastcall__ _oam_spr(unsigned long args);
+#define oam_spr(x, y, chrnum, attr)(loadBytesInSreg(x, y), __AX__ = (chrnum<<8)|attr, _oam_spr(__EAX__))
 
 
 //set metasprite in OAM buffer (normal)
@@ -109,8 +109,8 @@ void __fastcall__ oam_spr(unsigned char x,unsigned char y,unsigned char chrnum,u
 //x=128 is end of a meta sprite
 // Note: sprid removed for speed
 
-void __fastcall__ oam_meta_spr(unsigned char x,unsigned char y,const unsigned char *data);
-
+void __fastcall__ _oam_meta_spr(unsigned long args);
+#define oam_meta_spr(x, y, data)(loadBytesInSreg(x, y), __AX__ = (unsigned int)data, _oam_meta_spr(__EAX__))
 
 //hide all remaining sprites from given offset
 // Note: sprid removed for speed
@@ -147,7 +147,8 @@ unsigned char __fastcall__ pad_state(unsigned char pad);
 //set scroll, including the top bits
 //it is always applied at beginning of a TV frame, not at the function call
 
-void __fastcall__ scroll(unsigned int x,unsigned int y);
+void __fastcall__ _scroll(unsigned long args);
+#define scroll(x, y) (loadWordInSreg(x), __AX__ = y, _scroll(__EAX__))
 
 //set scroll after screen split invoked by the sprite 0 hit
 //warning: all CPU time between the function call and the actual split point will be wasted!
@@ -213,7 +214,8 @@ void __fastcall__ flush_vram_update(const unsigned char *buf);
 
 //fill a block with a byte at current vram address, works only when rendering is turned off
 
-void __fastcall__ vram_fill(unsigned char n,unsigned int len);
+void __fastcall__ _vram_fill(unsigned long args);
+#define vram_fill(n, len) (loadByteInSreg(byte(LSB(len))), __AX__ = (byte(MSB(len)) << 8) | byte(n), _vram_fill(__EAX__))
 
 //set vram autoincrement, 0 for +1 and not 0 for +32
 
@@ -221,11 +223,13 @@ void __fastcall__ vram_inc(unsigned char n);
 
 //read a block from current address of vram, works only when rendering is turned off
 
-void __fastcall__ vram_read(void *dst,unsigned int size);
+void __fastcall__ _vram_read(unsigned long args);
+#define vram_read(dst, size)(loadWordInSreg(dst), __AX__ = size, _vram_read(__EAX__))
 
 //write a block to current address of vram, works only when rendering is turned off
 
-void __fastcall__ vram_write(const void *src,unsigned int size);
+void __fastcall__ _vram_write(const void *src,unsigned int size);
+#define vram_write(src, size)(loadWordInSreg(src), __AX__ = size, _vram_write(__EAX__))
 
 //unpack RLE data to current address of vram, mostly used for nametables
 

--- a/LIB/neslib.s
+++ b/LIB/neslib.s
@@ -15,14 +15,14 @@
 	.export _pal_all,_pal_bg,_pal_spr,_pal_clear
 	.export _pal_bright,_pal_spr_bright,_pal_bg_bright
 	.export _ppu_off,_ppu_on_all,_ppu_on_bg,_ppu_on_spr,_ppu_mask,_ppu_system
-	.export _oam_clear,_oam_size,_oam_spr,_oam_meta_spr,_oam_hide_rest
+	.export _oam_clear,_oam_size,__oam_spr,__oam_meta_spr,_oam_hide_rest
 	.export _ppu_wait_frame,_ppu_wait_nmi
-	.export _scroll,_split
+	.export __scroll,_split
 	.export _bank_spr,_bank_bg
-	.export _vram_read,_vram_write
+	.export __vram_read,__vram_write
 	.export _pad_poll,_pad_trigger,_pad_state
 	.export _rand8,_rand16,_set_rand
-	.export _vram_fill,_vram_inc,_vram_unrle
+	.export __vram_fill,_vram_inc,_vram_unrle
 	.export _set_vram_update,_flush_vram_update
 	.export _memcpy,_memfill,_delay
 	
@@ -400,32 +400,24 @@ _oam_size:
 ;void __fastcall__ oam_spr(unsigned char x,unsigned char y,unsigned char chrnum,unsigned char attr);
 ;sprid removed
 
-_oam_spr:
+__oam_spr:
+	; a = attr
+	; x = chrnum
+	; sreg[0] = x
+	; sreg[1] = y
 
-	ldx SPRID
-	;a = chrnum
-	sta OAM_BUF+2,x
+	ldy SPRID
+	;a = attr
+	sta OAM_BUF+2,y
 
-	ldy #0		;3 popa calls replacement
-	lda (sp),y
-	iny
-	sta OAM_BUF+1,x
-	lda (sp),y
-	iny
-	sta OAM_BUF+0,x
-	lda (sp),y
-	sta OAM_BUF+3,x
+	txa	; tile
+	sta OAM_BUF+1,y
+	lda sreg+1	; y
+	sta OAM_BUF+0,y
+	lda sreg+0	; x
+	sta OAM_BUF+3,y
 
-	lda <sp
-	clc
-	adc #3 ;4
-	sta <sp
-	; bcc @1
-	; inc <sp+1	; lmao our stack is 32 bytes
-
-@1:
-
-	txa
+	tya
 	clc
 	adc #4
 	sta SPRID
@@ -436,17 +428,21 @@ _oam_spr:
 ;void __fastcall__ oam_meta_spr(unsigned char x,unsigned char y,const unsigned char *data);
 ;sprid removed
 
-_oam_meta_spr:
+__oam_meta_spr:
+	; AX = data
+	; sreg[0] = x
+	; sreg[1] = y
 
 	sta <PTR
 	stx <PTR+1
 
-	ldy #1		;2 popa calls replacement, performed in reversed order
-	lda (sp),y
-	dey
-	sta <SCRX
-	lda (sp),y
-	sta <SCRY
+	; ldy #1		;2 popa calls replacement, performed in reversed order
+	; lda (sp),y
+	; dey
+	; sta <SCRX
+	; lda (sp),y
+	; sta <SCRY
+	ldy #0
 
 oam_meta_spr_params_set:	; Put &data into PTR, X and Y into SCRX and SCRY respectively
 	
@@ -459,7 +455,7 @@ oam_meta_spr_params_set:	; Put &data into PTR, X and Y into SCRX and SCRY respec
 	beq @2
 	iny
 	clc
-	adc <SCRX
+	adc sreg+0	; x
 	bcc @fuck_yes
 	cpx #$00
 	beq @fuck_yes	; no idea why I need to do this
@@ -472,7 +468,7 @@ oam_meta_spr_params_set:	; Put &data into PTR, X and Y into SCRX and SCRY respec
 	lda (PTR),y		;y offset
 	iny
 	clc
-	adc <SCRY
+	adc sreg+1	; y
 	@hell_yes:
 	sta OAM_BUF+0,x
 	lda (PTR),y		;tile
@@ -622,9 +618,11 @@ _vram_unrle:
 
 
 
-;void __fastcall__ scroll(unsigned int x,unsigned int y);
+;void __fastcall__ _scroll(unsigned int x,unsigned int y);
 
-_scroll:
+__scroll:
+	; ax = y
+	; sreg = x
 
 	sta <TEMP
 
@@ -649,9 +647,9 @@ _scroll:
 
 @2:
 
-	jsr popax
+	lda sreg
 	sta <SCROLL_X
-	txa
+	lda sreg+1
 	and #$01
 	ora <TEMP
 	sta <TEMP
@@ -737,14 +735,17 @@ _bank_bg:
 
 ;void __fastcall__ vram_read(unsigned char *dst,unsigned int size);
 
-_vram_read:
+__vram_read:
+
+	; ax = size
+	; sreg = dst
 
 	sta <TEMP
 	stx <TEMP+1
 
-	jsr popax
-	sta <TEMP+2
-	stx <TEMP+3
+	; jsr popax
+	; sta sreg
+	; stx sreg+1
 
 	lda PPU_DATA
 
@@ -753,10 +754,10 @@ _vram_read:
 @1:
 
 	lda PPU_DATA
-	sta (TEMP+2),y
-	inc <TEMP+2
+	sta (sreg),y
+	inc sreg
 	bne @2
-	inc <TEMP+3
+	inc sreg+1
 
 @2:
 
@@ -777,24 +778,26 @@ _vram_read:
 
 ;void __fastcall__ vram_write(unsigned char *src,unsigned int size);
 
-_vram_write:
+__vram_write:
+	; ax = size
+	; sreg = src
 
 	sta <TEMP
 	stx <TEMP+1
 
-	jsr popax
-	sta <TEMP+2
-	stx <TEMP+3
+	; jsr popax
+	; sta <sreg
+	; stx <sreg+1
 
 	ldy #0
 
 @1:
 
-	lda (TEMP+2),y
+	lda (sreg),y
 	sta PPU_DATA
-	inc <TEMP+2
+	inc <sreg
 	bne @2
-	inc <TEMP+3
+	inc <sreg+1
 
 @2:
 
@@ -1082,26 +1085,30 @@ _flush_vram_update2: ;minor changes %
 
 ;void __fastcall__ vram_fill(unsigned char n,unsigned int len);
 
-_vram_fill:
+__vram_fill:
+	; a = n
+	; x = hi(len)
+	; sreg[0] = lo(len) 
 
-	sta <LEN
-	stx <LEN+1
-	jsr popa
-	ldx <LEN+1
+	; sta <LEN
+	; stx <LEN+1
+	; jsr popa
+	; ldx <LEN+1
+	cpx #0
 	beq @2
-	ldx #0
+	ldy #0
 
 @1:
 
 	sta PPU_DATA
-	dex
+	dey
 	bne @1
-	dec <LEN+1
+	dex
 	bne @1
 
 @2:
 
-	ldx <LEN
+	ldx sreg
 	beq @4
 
 @3:

--- a/LIB/neslib.s
+++ b/LIB/neslib.s
@@ -1211,7 +1211,6 @@ __memfill:
 @fill_start:
 
 	ldy #0
-	lda <TEMP
 
 @fill_loop:
 

--- a/LIB/neslib.s
+++ b/LIB/neslib.s
@@ -436,12 +436,6 @@ __oam_meta_spr:
 	sta <PTR
 	stx <PTR+1
 
-	; ldy #1		;2 popa calls replacement, performed in reversed order
-	; lda (sp),y
-	; dey
-	; sta <SCRX
-	; lda (sp),y
-	; sta <SCRY
 	ldy #0
 
 oam_meta_spr_params_set:	; Put &data into PTR, X and Y into SCRX and SCRY respectively

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -100,8 +100,6 @@ unsigned char gamemode;
 unsigned char cube_data[2];
 unsigned short cube_rotate[2];
 
-
-
 unsigned char collision;
 unsigned char collision_L;
 unsigned char collision_R;

--- a/SAUCE/gamestates/state_menu.h
+++ b/SAUCE/gamestates/state_menu.h
@@ -84,7 +84,7 @@ const char* const coin_counter[] = {
 */
 void __fastcall__ refreshmenu(void) {
 	#include "../defines/color1_charmap.h"
-	tmpptr1 = leveltexts[level & 0x7F];
+	tmpptr1 = (void *)leveltexts[level & 0x7F];
 	if (tmpptr1) draw_padded_text(level_text_size[level], 17, NTADR_A(8, 10));
 	else one_vram_buffer_horz_repeat(' ', 17, NTADR_A(8, 10));
 	// if (leveltexts2[level]) // always true


### PR DESCRIPTION
LOTS OF BYTES SAVED:
`CODE:        7210 → 7075 - diff:  135`
`ZEROPAGE:    160  → 164  - diff: -4`
`CODE_2:      4549 → 4525 - diff:  24`
`NESLIB:      1727 → 1652 - diff:  75`
`XCD_BANK_00: 7303 → 7240 - diff:  63`
`NESDOUG:     1489 → 1410 - diff:  79`
`LVL_BANK_08: 2294 → 2260 - diff:  34`
`XCD_BANK_03: 7457 → 7249 - diff:  208`
`LVL_BANK_00: 2445 → 2390 - diff:  55`

Total size reduction: 669 bytes
ROM size reduction: 673 bytes
Fixed bank size reduction: 313 bytes

***313 bytes*** of ***fixed bank space*** **free**

How to use the new system:
first 2 bytes go into __AX__ and then a single `unsigned short` argument of __AX__
if 3 bytes, 3rd goes into sreg+0 via the `storeByteToSreg` macro, then func is called with an `unsigned long` argument of `__EAX__`
if 4 bytes, 3rd and 4th go into sreg via the `storeBytesToSreg` or `storeWordToSreg` macro, then func is called with an `unsigned long` argument of `__EAX__`
if 5..8 bytes, the rest go into `xargs` (it's an array). there's also `wxargs` which is a handy thing that interprets `xargs` as an array of 2 unsigned shorts

the entire thing should be in a macro ofc 