### PR TITLE
Fix base after base coin

### DIFF
--- a/LEVELS/LEVEL DATA/baseafterbase.tmx
+++ b/LEVELS/LEVEL DATA/baseafterbase.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="869" height="27" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="1">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="869" height="27" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="1">
  <editorsettings>
   <chunksize width="16" height="27"/>
   <export target="baseafterbase.csv" format="csv"/>

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -331,12 +331,13 @@ void state_game(){
 		mmc3_set_prg_bank_1(GET_BANK(movement));
 		
 		movement();
-		
-		mmc3_set_prg_bank_1(GET_BANK(x_movement));
-		
-		x_movement();
+
 		mmc3_set_prg_bank_1(GET_BANK(x_movement_coll));
 		x_movement_coll();
+		
+		mmc3_set_prg_bank_1(GET_BANK(x_movement));
+		x_movement();
+		
 		mmc3_set_prg_bank_1(GET_BANK(sprite_collide));
 		sprite_collide();
 


### PR DESCRIPTION
Its funny, but the side collision was checked one frame ahead of the current pos, so it resulted on dying before visually hitting the block.