### PR TITLE
Sprite system overhaul 

### DIFF
--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1342,18 +1342,20 @@ early_exit:
 
 check_sprite_loop:
         ; X is the current sprite object
-        ; Load two byte X coord to see if we went offscreen
-        lda _activesprites_x_lo, x
-        sec
-        sbc _scroll_x
-        lda _activesprites_x_hi, x
-        sbc _scroll_x+1
+		lda _activesprites_type, x	;	If the sprite (e.g. color triggers)
+		cmp #$ff					;	has been marked as "complete",
+		beq sprite_dead				;__
+		
+        lda _activesprites_x_lo, x	;
+        sec							;	Or the sprite has
+        sbc _scroll_x				;	went offscreen,
+        lda _activesprites_x_hi, x	;
+        sbc _scroll_x+1				;__
         bpl sprite_alive
-            txa
-            pha
-                jsr load_next_sprite	; very convenient - we just stored the slot in A
-            pla
-            tax
+
+	sprite_dead:					;__	Load a new one in its place
+            txa						;	Takes the "slot" argument in A
+			jsr load_next_sprite	;__	But also preserves the X
             lda #0
             jmp write_active
     sprite_alive:

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -233,7 +233,6 @@ uint8_t player_gravity[2];
 
 
 uint8_t rld_column;
-uint8_t spr_index;
 uint8_t long_temp_x;
 
 uint8_t kandokidshack;

--- a/SAUCE/functions/sprite_loading.h
+++ b/SAUCE/functions/sprite_loading.h
@@ -118,7 +118,7 @@
 #define GRAVITY_PAD_UP_INVISIBLE		0XFE
 #define NOSPRITE				0XFF
 
-extern void load_next_sprite(void);
+extern void load_next_sprite(uint8_t slot);
 
 extern void check_spr_objects(void);
 
@@ -152,12 +152,12 @@ void init_sprites(void){	// required to be in a fixed bank
 
 	for (tmp4 = max_loaded_sprites-1; tmp4 != 0; --tmp4) activesprites_type[tmp4] = 0xFF;
 
-	spr_index = 0;
+	tmp4 = max_loaded_sprites;
 	do {
 		if (sprite_data[0] == TURN_OFF) break;
-		load_next_sprite();
-		if (activesprites_x_hi[spr_index] != 0) activesprites_active[spr_index] = 0;
-	} while (spr_index != 0);
+		load_next_sprite(--tmp4);
+		if (activesprites_x_hi[tmp4] != 0) activesprites_active[tmp4] = 0;
+	} while (tmp4 != 0);
 }
 
 #pragma code-name(push, "XCD_BANK_00")


### PR DESCRIPTION
now sprites are loaded into arbitrary slots, spr_index is gone, and a new sprite is loaded into any slot as soon as the last one dissapears, either offscreen or replaced by sprite 0xFF